### PR TITLE
Add filter version of amplifier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,31 +49,35 @@ To do x10 for messages 1/10 sampled, and to do x100 for messages 1/100 sampled:
 Filter version of AmplifierFilterOutput plugin.
 It depends on Fluentd 0.12 or later.
 
-    <match sampled_10.**>
+    <filter sampled_10.**>
       type amplifier_filter
       ratio 10
       key_names counts,rates
-    </match>
+    </filter>
 
-    <match sampled_100.**>
+    <filter sampled_100.**>
       type amplifier_filter
       ratio 100
       key_names counts,rates
+    </filter>
+
+    <match sampled_10.**>
+      # output configurations where to send original/modified messages...
     </match>
 
-    <match logs.**>
+    <match sampled_100.**>
       # output configurations where to send original/modified messages...
     </match>
 
 `key_pattern`(regexp) useful insted of `key_names`, and `add_prefix` is also useful:
 
-    <match sampled_10.**>
+    <filter sampled_10.**>
       type amplifier_filter
       ratio 10
       key_pattern .*_(count|rate)$
-    </match>
+    </filter>
 
-    <match summary.**>
+    <match sampled_10.**>
       # output configurations where to send original/modified messages...
     </match>
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,40 @@ To do x10 for messages 1/10 sampled, and to do x100 for messages 1/100 sampled:
       add_prefix summary
       key_pattern .*_(count|rate)$
     </match>
-    
+
+    <match summary.**>
+      # output configurations where to send original/modified messages...
+      </match>
+
+### AmplifierFilter
+
+Filter version of AmplifierFilterOutput plugin.
+It depends on Fluentd 0.12 or later.
+
+    <match sampled_10.**>
+      type amplifier_filter
+      ratio 10
+      key_names counts,rates
+    </match>
+
+    <match sampled_100.**>
+      type amplifier_filter
+      ratio 100
+      key_names counts,rates
+    </match>
+
+    <match logs.**>
+      # output configurations where to send original/modified messages...
+    </match>
+
+`key_pattern`(regexp) useful insted of `key_names`, and `add_prefix` is also useful:
+
+    <match sampled_10.**>
+      type amplifier_filter
+      ratio 10
+      key_pattern .*_(count|rate)$
+    </match>
+
     <match summary.**>
       # output configurations where to send original/modified messages...
     </match>

--- a/lib/fluent/plugin/filter_amplifier.rb
+++ b/lib/fluent/plugin/filter_amplifier.rb
@@ -1,0 +1,86 @@
+class Fluent::AmplifierFilter < Fluent::Filter
+  Fluent::Plugin.register_filter('amplifier_filter', self)
+
+  config_param :ratio, :float
+
+  config_param :key_names, :string, :default => nil
+  config_param :key_pattern, :string, :default => nil
+
+  config_param :floor, :bool, :default => false
+
+  # Define `log` method for v0.10.42 or earlier
+  unless method_defined?(:log)
+    define_method("log") { $log }
+  end
+
+  def configure(conf)
+    super
+
+    if @key_names.nil? and @key_pattern.nil?
+      raise Fluent::ConfigError, "missing both of key_names and key_pattern"
+    end
+    if not @key_names.nil? and not @key_pattern.nil?
+      raise Fluent::ConfigError, "cannot specify both of key_names and key_pattern"
+    end
+    if @key_names
+      @key_names = @key_names.split(',')
+    end
+    if @key_pattern
+      @key_pattern = Regexp.new(@key_pattern)
+    end
+
+    amp = if @floor
+            method(:amp_with_floor)
+          else
+            method(:amp_without_floor)
+          end
+    (class << self; self; end).module_eval do
+      define_method(:amp, amp)
+    end
+  end
+
+  def amp_without_floor(value)
+    value.to_f * @ratio
+  end
+
+  def amp_with_floor(value)
+    (value.to_f * @ratio).floor
+  end
+
+  def filter_stream(tag, es)
+    new_es = Fluent::MultiEventStream.new
+    if @key_names
+      es.each {|time,record|
+        updated = {}
+        @key_names.each {|key|
+          val = record[key]
+          next unless val
+          updated[key] = amp(val)
+        }
+        log.debug "amplifier tag:#{tag} floor:#{@floor} ratio:#{@ratio} updated:#{updated.to_json} record:#{record.to_json}"
+        if updated.size > 0
+          new_es.add(time, record.merge(updated))
+        else
+          new_es.add(time, record.dup)
+        end
+      }
+    else @key_pattern
+      es.each {|time,record|
+        updated = {}
+        record.keys.each {|key|
+          val = record[key]
+          next unless val
+          next unless @key_pattern.match(key)
+          updated[key] = amp(val)
+        }
+        log.debug "amplifier tag:#{tag} floor:#{@floor} ratio:#{@ratio} updated:#{updated.to_json} record:#{record.to_json}"
+        if updated.size > 0
+          new_es.add(time, record.merge(updated))
+        else
+          new_es.add(time, record.dup)
+        end
+      }
+    end
+    new_es
+  end
+end if defined?(Fluent::Filter)

--- a/lib/fluent/plugin/filter_amplifier.rb
+++ b/lib/fluent/plugin/filter_amplifier.rb
@@ -3,10 +3,10 @@ class Fluent::AmplifierFilter < Fluent::Filter
 
   config_param :ratio, :float
 
-  config_param :key_names, :string, :default => nil
-  config_param :key_pattern, :string, :default => nil
+  config_param :key_names, :string, default: nil
+  config_param :key_pattern, :string, default: nil
 
-  config_param :floor, :bool, :default => false
+  config_param :floor, :bool, default: false
 
   # Define `log` method for v0.10.42 or earlier
   unless method_defined?(:log)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,6 +25,7 @@ else
 end
 
 require 'fluent/plugin/out_amplifier_filter'
+require 'fluent/plugin/filter_amplifier'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_amplifier.rb
+++ b/test/plugin/test_filter_amplifier.rb
@@ -86,21 +86,6 @@ class AmplifierFilterTest < Test::Unit::TestCase
     assert_equal 50      , second['zap']
   end
 
-  def test_filter_2
-    # CONFIG = %[
-    #   ratio 1.5
-    #   key_names foo,bar,baz
-    # ]
-    d2 = create_driver(CONFIG, 'test')
-    d2.run do
-      d2.filter({'name' => 'first',  'foo' => 10, 'bar' => 1, 'baz' => 20, 'zap' => 50})
-      d2.filter({'name' => 'second', 'foo' => 10, 'bar' => 2, 'baz' => 40, 'zap' => 50})
-    end
-    filtered = d2.filtered_as_array
-    assert_equal 2, filtered.length
-    assert_equal 'test', filtered[0][0] # tag
-  end
-
   def test_filter_3
     # CONFIG2 = %[
     #   ratio 0.75

--- a/test/plugin/test_filter_amplifier.rb
+++ b/test/plugin/test_filter_amplifier.rb
@@ -57,7 +57,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
     assert_equal ['foo', 'bar', 'baz'], d.instance.key_names
   end
 
-  def test_filter
+  def test_filter_1
     # CONFIG = %[
     #   ratio 1.5
     #   key_names foo,bar,baz
@@ -84,7 +84,13 @@ class AmplifierFilterTest < Test::Unit::TestCase
     assert_equal 3       , second['bar']
     assert_equal 60      , second['baz']
     assert_equal 50      , second['zap']
+  end
 
+  def test_filter_2
+    # CONFIG = %[
+    #   ratio 1.5
+    #   key_names foo,bar,baz
+    # ]
     d2 = create_driver(CONFIG, 'test')
     d2.run do
       d2.filter({'name' => 'first',  'foo' => 10, 'bar' => 1, 'baz' => 20, 'zap' => 50})
@@ -93,7 +99,9 @@ class AmplifierFilterTest < Test::Unit::TestCase
     filtered = d2.filtered_as_array
     assert_equal 2, filtered.length
     assert_equal 'test', filtered[0][0] # tag
+  end
 
+  def test_filter_3
     # CONFIG2 = %[
     #   ratio 0.75
     #   floor yes

--- a/test/plugin/test_filter_amplifier.rb
+++ b/test/plugin/test_filter_amplifier.rb
@@ -1,0 +1,125 @@
+require 'helper'
+
+class AmplifierFilterTest < Test::Unit::TestCase
+  def setup
+    if not defined?(Fluent::Filter)
+      omit("Fluent::Filter is not defined. Use fluentd 0.12 or later.")
+    end
+
+    Fluent::Test.setup
+  end
+
+  # config_param :ratio, :float
+  # config_param :key_names, :string, :default => nil
+  # config_param :key_pattern, :string, :default => nil
+  # config_param :floor, :bool, :default => false
+  # config_param :remove_prefix, :string, :default => nil
+  # config_param :add_prefix, :string, :default => nil
+
+  CONFIG = %[
+    ratio 1.5
+    key_names foo,bar,baz
+  ]
+  CONFIG2 = %[
+    ratio 0.75
+    floor yes
+    key_pattern field.*
+  ]
+
+  def create_driver(conf = CONFIG, tag='test')
+    Fluent::Test::FilterTestDriver.new(Fluent::AmplifierFilter, tag).configure(conf)
+  end
+
+  def test_configure
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver('')
+    }
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver(%[
+        ratio 1
+      ])
+    }
+    assert_nothing_thrown {
+      d = create_driver(%[
+        ratio 1
+        key_names field1
+      ])
+    }
+    assert_nothing_raised {
+      d = create_driver(%[
+        ratio 1
+        key_pattern field\d+
+      ])
+    }
+
+    d = create_driver
+    assert_equal false, d.instance.floor
+    assert_equal ['foo', 'bar', 'baz'], d.instance.key_names
+  end
+
+  def test_filter
+    # CONFIG = %[
+    #   ratio 1.5
+    #   key_names foo,bar,baz
+    # ]
+    d1 = create_driver(CONFIG, 'test.service')
+    d1.run do
+      d1.filter({'name' => 'first',  'foo' => 10, 'bar' => 1, 'baz' => 20, 'zap' => 50})
+      d1.filter({'name' => 'second', 'foo' => 10, 'bar' => 2, 'baz' => 40, 'zap' => 50})
+    end
+    filtered = d1.filtered_as_array
+    assert_equal 2, filtered.length
+    assert_equal 'test.service', filtered[0][0] # tag
+
+    first = filtered[0][2]
+    assert_equal 'first', first['name']
+    assert_equal 15     , first['foo']
+    assert_equal 1.5    , first['bar']
+    assert_equal 30     , first['baz']
+    assert_equal 50     , first['zap']
+
+    second = filtered[1][2]
+    assert_equal 'second', second['name']
+    assert_equal 15      , second['foo']
+    assert_equal 3       , second['bar']
+    assert_equal 60      , second['baz']
+    assert_equal 50      , second['zap']
+
+    d2 = create_driver(CONFIG, 'test')
+    d2.run do
+      d2.filter({'name' => 'first',  'foo' => 10, 'bar' => 1, 'baz' => 20, 'zap' => 50})
+      d2.filter({'name' => 'second', 'foo' => 10, 'bar' => 2, 'baz' => 40, 'zap' => 50})
+    end
+    filtered = d2.filtered_as_array
+    assert_equal 2, filtered.length
+    assert_equal 'test', filtered[0][0] # tag
+
+    # CONFIG2 = %[
+    #   ratio 0.75
+    #   floor yes
+    #   key_pattern field.*
+    # ]
+    d3 = create_driver(CONFIG2, 'test.service')
+    d3.run do
+      d3.filter({'name' => 'first',  'fieldfoo' => 10, 'fieldbar' => 1, 'fieldbaz' => 20, 'zap' => 50})
+      d3.filter({'name' => 'second', 'fieldfoo' => '10', 'fieldbar' => '2', 'fieldbaz' => '40', 'zap' => '50'})
+    end
+    filtered = d3.filtered_as_array
+    assert_equal 2, filtered.length
+    assert_equal 'test.service', filtered[0][0] # tag
+
+    first = filtered[0][2]
+    assert_equal 'first', first['name']
+    assert_equal 7      , first['fieldfoo']
+    assert_equal 0      , first['fieldbar']
+    assert_equal 15     , first['fieldbaz']
+    assert_equal 50     , first['zap']
+
+    second = filtered[1][2]
+    assert_equal 'second', second['name']
+    assert_equal 7       , second['fieldfoo']
+    assert_equal 1       , second['fieldbar']
+    assert_equal 30      , second['fieldbaz']
+    assert_equal '50'    , second['zap']
+  end
+end

--- a/test/plugin/test_filter_amplifier.rb
+++ b/test/plugin/test_filter_amplifier.rb
@@ -86,7 +86,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
     assert_equal 50      , second['zap']
   end
 
-  def test_filter_3
+  def test_filter_2
     # CONFIG2 = %[
     #   ratio 0.75
     #   floor yes


### PR DESCRIPTION
* Add filter version of amplifier plugin
* Add filter version configuration description in document

Dependent fluentd version is not locked in gemspec.
So, I added checking code whether `Fleunt::Filter` defined or not.